### PR TITLE
Allow edit profile from front-end. Fix #1

### DIFF
--- a/src/AuthFieldsExtension.php
+++ b/src/AuthFieldsExtension.php
@@ -50,9 +50,7 @@ class AuthFieldsExtension extends SimpleExtension
 
         $type = new ProfileEditType($app['auth.config'], $this->getConfig());
 
-        $entityClassName = Profile::class;
-
         $event->setType($type);
-        $event->setEntityClass($entityClassName);
+        $event->setEntityClass(null);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/BoltAuth/AuthFields/issues/1

It seems `null` works just fine because it means it doesn't override with a new entity.